### PR TITLE
Fix for incorrect org_id

### DIFF
--- a/assets/js/donation.js
+++ b/assets/js/donation.js
@@ -114,6 +114,8 @@ function donationInit(form){
 			return false;
 		}
 
+		var org_id = form.attr('data-orgid');
+
 		var url = form.attr('action');
 		if (url.substr(url.length - 1) !== '/') {
 			url += '/';
@@ -127,11 +129,11 @@ function donationInit(form){
 		if ($frequency.val() === 'once') {
 			url
 				+= 'donateform'
-				+ '?org_id=newsmatch'
+				+ '?org_id=' + org_id
 				+ '&amount=' + amount.toFixed(2);
 		} else {
 			url += 'memberform'
-				+ '?org_id=newsmatch'
+				+ '?org_id=' + org_id
 				+ '&amount=' + amount.toFixed(2)
 				+ '&installmentPeriod=' + $frequency.val();
 		}

--- a/views/donation-form-buttons.view.php
+++ b/views/donation-form-buttons.view.php
@@ -1,5 +1,5 @@
 <div>
-	<form class="newsmatch-donation-form form-inline level-<?php echo esc_attr( $data['level'] ); ?>" action="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" method="POST">
+	<form class="newsmatch-donation-form form-inline level-<?php echo esc_attr( $data['level'] ); ?>" action="<?php echo esc_attr( esc_url( $data['url'] ) ); ?>" method="POST" data-orgid="<?php echo esc_attr( $data['org_id'] ); ?>">
 		<div class="newsmatch-donate-label">I would like to donate:</div>
 		<div class="form-group">
 			<label class="newsmatch-donation-amount-label" for="newsmatch-donation-amount">I would like to donate:</label>


### PR DESCRIPTION
## Changes

- Sets the organization's ID as data on the form, so that it can be incorporated into the submission URL.

## Why

So that the organization ID is not the default 'newsmatch'
For https://github.com/INN/news-match-donation-shortcode/issues/17