### PR TITLE
Add default donation amount

### DIFF
--- a/classes/class-newsmatchdonation-shortcode.php
+++ b/classes/class-newsmatchdonation-shortcode.php
@@ -124,7 +124,7 @@ class NewsMatchDonation_Shortcode {
 				'url' => $this->get_url(),
 				'org_id' => esc_attr( get_option( $this->option_prefix . 'org_id', '' ) ),
 				'sf_campaign_id' => esc_attr( get_option( $this->option_prefix . 'sf_campaign_id', '' ) ),
-				'amount' => '15',
+				'amount' => esc_attr( get_option( $this->option_prefix . 'default_donation', 15 ) ),
 				'level' => 'individual',
 			),
 			$atts


### PR DESCRIPTION
## Changes

- adds settings field for default donation amount, using browser validation to request that it be >= 0.01
- aggressively sanitizes it serverside to that it's >= 0.01
- uses that amount in the shortcode.
- also some minor WordPress VIP PHPCS stuff

Resolves #15.